### PR TITLE
Update GUARD PATH

### DIFF
--- a/libguard/guard_interface.cpp
+++ b/libguard/guard_interface.cpp
@@ -40,15 +40,8 @@ void initialize()
     {
         if (!fs::exists(GUARD_PRSV_PATH))
         {
-            if (fs::exists(GUARD_RO_PATH))
-            {
-                fs::copy_file(GUARD_RO_PATH, GUARD_PRSV_PATH);
-            }
-            else
-            {
-                guard_log(GUARD_ERROR, "Fail to find guard file %s",
-                          GUARD_RO_PATH);
-            }
+            guard_log(GUARD_ERROR, "Fail to find guard file %s",
+                      GUARD_PRSV_PATH);
         }
         guardFilePath = GUARD_PRSV_PATH;
     }

--- a/meson.build
+++ b/meson.build
@@ -21,11 +21,8 @@ add_project_arguments('-Wno-psabi', language: 'cpp')
 
 conf_data = configuration_data()
 
-conf_data.set_quoted('GUARD_RO_PATH', get_option('GUARD_RO_PATH'),
-                      description : 'GUARD file in pnor ro partition'
-                    )
 conf_data.set_quoted('GUARD_PRSV_PATH', get_option('GUARD_PRSV_PATH'),
-                      description : 'GUARD file in pnor prsv partition'
+                      description : 'GUARD file that is preserved'
                     )
 
 conf_data.set_quoted('GUARD_VERSION', 'v1.0',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,14 +1,9 @@
 option('tests', type: 'feature', description: 'Build tests')
 option('oe-sdk', type: 'feature', description: 'Enable OE SDK')
 
-option('GUARD_RO_PATH', type : 'string',
-        value : '/var/lib/phosphor-software-manager/pnor/ro/GUARD',
-        description : 'GUARD file path in ro partition'
-      )
-
 option('GUARD_PRSV_PATH', type : 'string',
-        value : '/var/lib/phosphor-software-manager/pnor/prsv/GUARD',
-        description : 'GUARD file path in prsv partition'
+        value : '/var/lib/phosphor-software-manager/hostfw/running/GUARD',
+        description : 'GUARD file path that is preserved'
       )
 
 option('devtree', type: 'feature', value : 'disabled',


### PR DESCRIPTION
The pnor directories are being replaced with the hostfw directories that
are handled by PLDM. In addition, all the files are copied when the BMC
first starts up so there is no need for the guard app to manually copy
the GUARD file from the read-only location.

Tested: Ran guard -l successfully, and when deleting GUARD (this would
be an error scenario), an error was displayed:
Fail to find guard file
/var/lib/phosphor-software-manager/hostfw/running/GUARD

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>