### PR TITLE
libguard: Setting eId to 0, when record changed to manual

### DIFF
--- a/libguard/guard_interface.cpp
+++ b/libguard/guard_interface.cpp
@@ -159,6 +159,7 @@ GuardRecord create(const EntityPath& entityPath, uint32_t eId, uint8_t eType)
                 offset = lastPos * sizeOfGuard;
                 existGuard.errType = eType;
                 existGuard.recordId = htobe32(lastPos + 1);
+                existGuard.elogId = htobe32(eId);
                 file.write(offset + headerSize, &existGuard, sizeOfGuard);
             }
             else if (existGuard.recordId == GUARD_RESOLVED)


### PR DESCRIPTION
Change:
-Setting errorlog Id to 0, when the guard record is changed
from reconfig type to manual.

Tested:
-Created guard record with reconfig type and overwrite the
same with manual type. Eid is getting set to 0.

Signed-off-by: Chirag Sharma <chirshar@in.ibm.com>