### PR TITLE
libguard: Introduced "GARD_Sticky_deconfig" type to guard

### DIFF
--- a/guard.cpp
+++ b/guard.cpp
@@ -22,8 +22,10 @@ void guardList(bool displayResolved)
     for (const auto& elem : records)
     {
         // Not to print guard records with errorlog type set as GARD_Reconfig
+        // or GARD_Sticky_deconfig
         // As guard below type records are for internal usage only.
-        if (elem.errType == GARD_Reconfig)
+        if (elem.errType == GARD_Reconfig ||
+            elem.errType == GARD_Sticky_deconfig)
         {
             continue;
         }

--- a/libguard/guard_interface.cpp
+++ b/libguard/guard_interface.cpp
@@ -154,7 +154,8 @@ GuardRecord create(const EntityPath& entityPath, uint32_t eId, uint8_t eType)
 
         if (existGuard.targetId == entityPath)
         {
-            if (existGuard.errType == GARD_Reconfig)
+            if (existGuard.errType == GARD_Reconfig ||
+                existGuard.errType == GARD_Sticky_deconfig)
             {
                 offset = lastPos * sizeOfGuard;
                 existGuard.errType = eType;

--- a/libguard/include/guard_record.hpp
+++ b/libguard/include/guard_record.hpp
@@ -84,6 +84,8 @@ enum GardType
     GARD_Power = 0xE9,
     GARD_PHYP = 0xEA,
     GARD_Reconfig = 0xEB,
+    GARD_Sticky_deconfig = 0xEC, // Force deconfig on reconfig loop,
+                                 // not availible for resource recovery.
     GARD_Void = 0xFF,
 };
 


### PR DESCRIPTION
- The host application introduced the "GARD_Sticky_deconfig" type
  for the guard operation to support resource recovery during
  the boot of the host.

- Added the same support in the libguard to use by the BMC application.

  - Allowed to override "Sticky" type record like the "Reconfig" type.

  - Did not display the "Sticky" type record like the "Reconfig" type.