### PR TITLE
libguard: Added persistentTypeOnly flag in the getAll interface

### DIFF
--- a/guard.cpp
+++ b/guard.cpp
@@ -11,7 +11,10 @@ using namespace openpower::guard;
 
 void guardList(bool displayResolved)
 {
-    auto records = getAll();
+    // Don't get ephemeral records because those type records are not intended
+    // to expose to the end user, just created for internal purpose to use
+    // by the BMC and Hostboot.
+    auto records = getAll(true);
     if (!records.size())
     {
         std::cout << "No Records to display" << std::endl;
@@ -21,16 +24,8 @@ void guardList(bool displayResolved)
     bool isHeaderPrinted = false;
     for (const auto& elem : records)
     {
-        // Not to print guard records with errorlog type set as GARD_Reconfig
-        // or GARD_Sticky_deconfig
-        // As guard below type records are for internal usage only.
-        if (elem.errType == GARD_Reconfig ||
-            elem.errType == GARD_Sticky_deconfig)
-        {
-            continue;
-        }
         // To list resolved records as user wants to list resolved records
-        else if (displayResolved && (elem.recordId != GUARD_RESOLVED))
+        if (displayResolved && (elem.recordId != GUARD_RESOLVED))
         {
             continue;
         }

--- a/libguard/guard_interface.cpp
+++ b/libguard/guard_interface.cpp
@@ -260,7 +260,7 @@ GuardRecord create(const EntityPath& entityPath, uint32_t eId, uint8_t eType,
     return getHostEndiannessRecord(guard);
 }
 
-GuardRecords getAll()
+GuardRecords getAll(bool persistentTypeOnly)
 {
     GuardRecords guardRecords;
     GuardRecord curRecord;
@@ -268,6 +268,11 @@ GuardRecords getAll()
     GuardFile file(guardFilePath);
     for_each_guard(file, pos, curRecord)
     {
+        if (persistentTypeOnly && (curRecord.errType == GARD_Reconfig ||
+                                   curRecord.errType == GARD_Sticky_deconfig))
+        {
+            continue;
+        }
         curRecord.recordId = be32toh(curRecord.recordId);
         curRecord.elogId = be32toh(curRecord.elogId);
         guardRecords.push_back(curRecord);

--- a/libguard/guard_interface.hpp
+++ b/libguard/guard_interface.hpp
@@ -43,13 +43,17 @@ GuardRecord create(const EntityPath& entityPath, uint32_t eId = 0,
 /**
  * @brief Get all the guard records
  *
+ * @param[in] persistentTypeOnly - Used to decide whether wants to get all
+ *                                 records or only persistent type records.
+ *                                 By default, get all records.
+ *
  * @return GuardRecords List of Guard Records.
  *         On failure will throw below exceptions:
  *         -GuardFileOpenFailed
  *         -GuardFileSeekFailed
  *         -GuardFileReadFailed
  */
-GuardRecords getAll();
+GuardRecords getAll(bool persistentTypeOnly = false);
 
 /**
  * @brief Clear the guard record


### PR DESCRIPTION
- Currently, the getAll interface returning all types (persistent and
  ephemeral) of guard records but, the ephemeral type records are
  used for internal purpose i.e, between the BMC and Host and those type
  of guard records not intended to expose to the end-user.

- So, the application (that used to list records to the end-user) is
  adding the filter to ignore the ephemeral type records so simplified
  the getAll interface to return only persistent type records if requested
  else return all types of records.

Tested:

- Verified by creating and listing the guard records.