### PR TITLE
guard: fix compiler error comparing the result of pointer additiong

### DIFF
--- a/libguard/guard_common.hpp
+++ b/libguard/guard_common.hpp
@@ -143,15 +143,6 @@ struct EntityPath
         for (int i = 0, j = 1; i < pathElementsSize;
              i++, j += sizeof(PathElement))
         {
-            if ((rawData + j) == nullptr || (rawData + j + 1) == nullptr)
-            {
-                openpower::guard::log::guard_log(
-                    GUARD_ERROR,
-                    "Insufficient data for PathElement in given raw data");
-                throw InvalidEntityPath(
-                    "EntityPath conversion constructor failed");
-            }
-
             pathElements[i].targetType = rawData[j];
             pathElements[i].instance = rawData[j + 1];
         }


### PR DESCRIPTION
Removed pointer increment and checking to nullptr check as we are
already using the size check.

Pointer arithmetic can never be a nullptr it will always be some
address in the memory.

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I56bb63dc09042637e6e4d4284bcbb6f30bd6a49e