### PR TITLE
1030: guard: To fix the record ID to contain the prefix '0x'

### DIFF
--- a/guard.cpp
+++ b/guard.cpp
@@ -11,13 +11,19 @@ using namespace openpower::guard;
 
 void printHeader()
 {
-    std::cout << "ID       | ERROR    |  Type  | Path " << std::endl;
+    std::cout << std::left << std::setfill(' ') << std::setw(10) << "ID";
+    std::cout << " | ";
+    std::cout << std::setfill(' ') << std::setw(10) << "ERROR";
+    std::cout << " | ";
+    std::cout << std::setfill(' ') << std::setw(15) << "Type";
+    std::cout << " | ";
+    std::cout << "Path" << std::endl;
 }
 
 void printRecord(const GuardRecord& record)
 {
-    std::cout << "0x" << std::hex << std::setw(8) << std::setfill('0')
-              << record.recordId;
+    std::cout << std::right << "0x" << std::hex << std::setw(8)
+              << std::setfill('0') << record.recordId;
 
     std::cout << " | ";
     std::cout << "0x" << std::hex << std::setw(8) << std::setfill('0')

--- a/guard.cpp
+++ b/guard.cpp
@@ -16,14 +16,16 @@ void printHeader()
 
 void printRecord(const GuardRecord& record)
 {
-    std::cout << std::hex << std::setw(8) << std::setfill('0')
+    std::cout << "0x" << std::hex << std::setw(8) << std::setfill('0')
               << record.recordId;
 
     std::cout << " | ";
-    std::cout << std::hex << std::setw(8) << std::setfill('0') << record.elogId;
+    std::cout << "0x" << std::hex << std::setw(8) << std::setfill('0')
+              << record.elogId;
 
     std::cout << " | ";
-    std::cout << guardReasonToStr(record.errType);
+    std::cout << std::left << std::setfill(' ') << std::setw(15)
+              << guardReasonToStr(record.errType);
 
     std::cout << " | ";
     std::optional<std::string> physicalPath = getPhysicalPath(record.targetId);


### PR DESCRIPTION
guard -l command : Formatted the record ID to display 0x and the header space to align

test:

root@rain104bmc:~# /tmp/guard -l
ID         | ERROR    | Type     | Path
0x10000000 | 00000000 | manual   | physical:sys-0/node-0/proc-1

Signed-off-by: deepakala-k <deepakala.karthikeyan@ibm.com>
Change-Id: I9c67945dea8a3098285e7270c67fe5697b25cea2