### PR TITLE
Update default guard version value to 2

### DIFF
--- a/libguard/include/guard_record.hpp
+++ b/libguard/include/guard_record.hpp
@@ -11,7 +11,7 @@ namespace guard
 
 #define GUARD_MAGIC "GUARDREC" //! "GUARDREC"
 /* From hostboot: src/include/usr/hwas/hwasPlatDeconfigGard.H */
-const uint8_t CURRENT_GARD_VERSION_LAYOUT = 0x1;
+const uint8_t CURRENT_GARD_VERSION_LAYOUT = 0x2;
 #define GUARD_RESOLVED 0xFFFFFFFF
 
 #ifdef PGUARD

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ conf_data.set_quoted('GUARD_PRSV_PATH', get_option('GUARD_PRSV_PATH'),
                       description : 'GUARD file that is preserved'
                     )
 
-conf_data.set_quoted('GUARD_VERSION', 'v1.0',
+conf_data.set_quoted('GUARD_VERSION', 'v2.0',
               description : 'Setting guard tool version'
              )
 


### PR DESCRIPTION
Updating default guard version to 2 in FW1060 as HostBoot had a version bump.

Before:
```
root@p10bmc:/tmp# guard -r
root@p10bmc:/tmp# guard -c sys-0/node-0/dimm-34
Success
root@p10bmc:/tmp#  hexdump -C /media/hostfw/running/81e00667.lid | head
00000000  47 55 41 52 44 52 45 43  01 ff ff ff ff ff ff ff  |GUARDREC........|
00000010  00 00 00 01 23 01 00 02  00 03 22 76 00 d0 93 76  |....#....."v...v|
00000020  e8 84 87 01 20 19 a5 76  00 00 00 00 00 d2 00 00  |.... ..v........|
00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000040  00 ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00000050  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
*
00005000
root@p10bmc:/tmp# guard -v
Guard tool v1.0
```

Test Results:
```
root@p10bmc:/tmp/test# guard -r
root@p10bmc:/tmp/test# guard -c sys-0/node-0/dimm-35
Success
root@p10bmc:/tmp/test#  hexdump -C /media/hostfw/running/81e00667.lid | head
00000000  47 55 41 52 44 52 45 43  02 ff ff ff ff ff ff ff  |GUARDREC........|
00000010  00 00 00 01 23 01 00 02  00 03 23 76 00 f0 95 76  |....#.....#v...v|
00000020  e8 14 42 01 20 39 a7 76  00 00 00 00 00 d2 00 00  |..B. 9.v........|
00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000040  00 ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00000050  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
*
00005000
root@p10bmc:/tmp/test# guard -v
Guard tool v2.0
```

Change-Id: Ib049c2f76ad1f35d5029928764e34d29430b0fed
Signed-off-by: Parasa Swetha <Parasa.Swetha1@ibm.com>