### PR TITLE
libguard: Spare core support

### DIFF
--- a/guard.cpp
+++ b/guard.cpp
@@ -184,7 +184,8 @@ int main(int argc, char** argv)
             "-i, --invalidate", recordId,
             "Invalidate a single Guard record, expects record id as input");
         app.add_flag("-I, --invalidate-all", invalidateAll,
-                     "Invalidates all the Guard records");
+                     "Invalidates all the Guard records other than the core "
+                     "Guard records");
         app.add_flag("-l, --list", listGuardRecords,
                      "List all the Guard'ed resources");
         app.add_flag("-r, --reset", clearAll, "Erase all the Guard records");

--- a/libguard/guard_interface.cpp
+++ b/libguard/guard_interface.cpp
@@ -391,6 +391,18 @@ void invalidateAll()
     {
         for_each_guard(file, pos, existGuard)
         {
+            std::optional<std::string> physicalPath =
+                getPhysicalPath(existGuard.targetId);
+            // Finding cores(both fused core and core) by looking at path
+            // (sys-*/node-*/proc-*/eq*/fc-*[/core-*])
+            if (physicalPath.has_value() &&
+                physicalPath.value().find("fc") != std::string::npos)
+            {
+                // There is a requirement to exclude cores when delete all
+                // deconfiguration records is attempted from GUI as well as CLI.
+                // This change is made as a part of spare core support.
+                continue;
+            }
             offset = pos * sizeof(existGuard);
             existGuard.recordId = GUARD_RESOLVED;
             file.write(offset + headerSize, &existGuard, sizeof(existGuard));

--- a/libguard/include/guard_record.hpp
+++ b/libguard/include/guard_record.hpp
@@ -77,6 +77,7 @@ struct GuardRecord_t
 enum GardType
 {
     GARD_NULL = 0x00,
+    GARD_Spare = 0xC0,
     GARD_User_Manual = 0xD2,
     GARD_Unrecoverable = 0xE2,
     GARD_Fatal = 0xE3,


### PR DESCRIPTION
Modify invalidateAll method so that it invalidates all records except core guard records.

Test Results:

``` 
root@p10bmc:/tmp# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x00000000 | manual          | physical:sys-0/node-0/generic_i2c_device-224
0x00000002 | 0x50003198 | predictive      | physical:sys-0/node-0/ocmb_chip-56/mem_port-0
0x00000003 | 0x50003199 | fatal           | physical:sys-0/node-0/dimm-112
0x00000004 | 0x00000000 | manual          | physical:sys-0/node-0/pmic-224
0x00000005 | 0x50003198 | predictive      | physical:sys-0/node-0/pmic-225
0x00000006 | 0x50003199 | fatal           | physical:sys-0/node-0/pmic-226
0x00000007 | 0x50003198 | predictive      | physical:sys-0/node-0/ocmb_chip-57
0x00000008 | 0x50003199 | fatal           | physical:sys-0/node-0/generic_i2c_device-228
0x00000009 | 0x00000000 | manual          | physical:sys-0/node-0/ocmb_chip-57/mem_port-0
0x0000000a | 0x50003198 | predictive      | physical:sys-0/node-0/dimm-114
0x0000000b | 0x00000000 | manual          | physical:sys-0/node-0/ocmb_chip-59
0x0000000c | 0x50003198 | predictive      | physical:sys-0/node-0/generic_i2c_device-236
0x0000000d | 0x50003199 | fatal           | physical:sys-0/node-0/ocmb_chip-59/mem_port-0
0x0000000e | 0x00000000 | manual          | physical:sys-0/node-0/dimm-118
0x0000000f | 0x50003199 | fatal           | physical:sys-0/node-0/ocmb_chip-60
0x00000010 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1
0x00000011 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/nx-0
0x00000012 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/nmmu-0
0x00000013 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/nmmu-1
0x00000014 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/pec-0
0x00000015 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/pec-0/phb-0
0x00000016 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/pec-0/phb-1
0x00000017 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/pec-0/phb-2
0x00000018 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/pec-1
0x00000019 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/mc-2
0x0000001a | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/mc-2/mi-0
0x0000001b | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/mc-2/mi-0/mcc-0
0x0000001c | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/mc-2/mi-0/mcc-0/omi-0
0x0000001d | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/mc-2/omic-0
0x0000001e | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/mc-3
0x0000001f | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/mc-3/mi-0
0x00000020 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/mc-3/mi-0/mcc-0
0x00000021 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/mc-3/mi-0/mcc-0/omi-0
0x00000022 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/mc-3/mi-0/mcc-1
0x00000023 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/mc-3/mi-0/mcc-1/omi-0
0x00000024 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/mc-3/omic-0
0x00000025 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/pauc-0
0x00000026 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/pauc-0/pau-0
0x00000027 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/pauc-1
0x00000028 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/pauc-1/pau-1
0x00000029 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/pauc-2
0x0000002a | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/pauc-0/iohs-1
0x0000002b | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/pauc-0/iohs-1/smpgroup-0
0x0000002c | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/pauc-0/iohs-1/smpgroup-1
0x0000002d | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/pauc-1/iohs-1
0x0000002e | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/pauc-1/iohs-1/smpgroup-0
0x0000002f | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/pauc-2/iohs-1
0x00000030 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/eq-0
0x00000031 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/eq-0/fc-0
0x00000032 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/eq-0/fc-0/core-0
0x00000033 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/eq-0/fc-0/core-1
0x00000034 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/eq-1
0x00000035 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/eq-1/fc-0
0x00000036 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/eq-1/fc-0/core-1
0x00000037 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/eq-2
0x00000038 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/eq-2/fc-0
0x00000039 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-2
0x0000003a | 0x50003199 | fatal           | physical:sys-0/node-0/proc-2/nx-0
0x0000003b | 0x00000000 | manual          | physical:sys-0/node-0/proc-2/nmmu-0
0x0000003c | 0x50003199 | fatal           | physical:sys-0/node-0/proc-2/pec-0
0x0000003d | 0x50003198 | predictive      | physical:sys-0/node-0/proc-2/mc-0
0x0000003e | 0x50003199 | fatal           | physical:sys-0/node-0/proc-2/mc-0/mi-0
0x0000003f | 0x00000000 | manual          | physical:sys-0/node-0/proc-2/mc-1/omic-0
0x00000040 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-2/pauc-1/pau-1
0x00000041 | 0x00000000 | manual          | physical:sys-0/node-0/proc-3
0x00000042 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-3/nx-0
0x00000043 | 0x00000000 | manual          | physical:sys-0/node-0/tpm-0

root@p10bmc:/tmp# guard -I
root@p10bmc:/tmp# guard -l
ID         | ERROR      | Type            | Path
0x00000031 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/eq-0/fc-0
0x00000032 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/eq-0/fc-0/core-0
0x00000033 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/eq-0/fc-0/core-1
0x00000035 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/eq-1/fc-0
0x00000036 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/eq-1/fc-0/core-1
0x00000038 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/eq-2/fc-0

root@p10bmc:/tmp# guard -i 0x00000031
root@p10bmc:/tmp# guard -l
ID         | ERROR      | Type            | Path
0x00000032 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/eq-0/fc-0/core-0
0x00000033 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/eq-0/fc-0/core-1
0x00000035 | 0x50003198 | predictive      | physical:sys-0/node-0/proc-1/eq-1/fc-0
0x00000036 | 0x00000000 | manual          | physical:sys-0/node-0/proc-1/eq-1/fc-0/core-1
0x00000038 | 0x50003199 | fatal           | physical:sys-0/node-0/proc-1/eq-2/fc-0

```

Change-Id: I26f3f7af7c3c7af8f21b88c46f3cba0b5fe16e30
Signed-off-by: SwethaParasa <parasa.swetha1@ibm.com>