### PR TITLE
Add create method to handle raw data input

### DIFF
--- a/libguard/guard_interface.cpp
+++ b/libguard/guard_interface.cpp
@@ -280,6 +280,15 @@ GuardRecord create(const EntityPath& entityPath, uint32_t eId, uint8_t eType,
     return getHostEndiannessRecord(guard);
 }
 
+
+GuardRecord create(std::vector<uint8_t> rawPath, uint32_t eId,
+                   uint8_t eType,
+                   bool overwriteRecord)
+{
+    return create(EntityPath(rawPath.data(), rawPath.size()), eId,
+    eType, overwriteRecord);
+}
+
 GuardRecords getAll(bool persistentTypeOnly)
 {
     GuardRecords guardRecords;

--- a/libguard/guard_interface.hpp
+++ b/libguard/guard_interface.hpp
@@ -41,6 +41,32 @@ GuardRecord create(const EntityPath& entityPath, uint32_t eId = 0,
                    bool overwriteRecord = true);
 
 /**
+ * @brief Create a guard record on the PNOR Partition file
+ *
+ * @details This function will overwrite the existing guard record
+ *          based on the given "overwriteRecord" flag if that's meets
+ *          a certain conditions that are defined in this function.
+ *
+ * @param[in] rawPathData entity path of the resource to be guarded as unit8 vector
+ * @param[in] eId errorlog ID
+ * @param[in] eType errorlog type
+ * @param[in] overwriteRecord used to decide overwrite existing record
+ *
+ * @return created guard record in host endianess format on success
+ *         Throw following exceptions on failure:
+ *         -GuardFileOverFlowed
+ *         -AlreadyGuarded
+ *         -GuardFileOpenFailed
+ *         -GuardFileSeekFailed
+ *         -GuardFileReadFailed
+ *         -GuardFileWriteFailed
+ *
+ */
+GuardRecord create(std::vector<uint8_t> rawPath, uint32_t eId = 0,
+                   uint8_t eType = GARD_User_Manual,
+                   bool overwriteRecord = true);
+
+/**
  * @brief Get all the guard records
  *
  * @param[in] persistentTypeOnly - Used to decide whether wants to get all


### PR DESCRIPTION
This new method allows the creation of guard records directly from raw data, eliminating the need for the calling repository to define the EntityPath structure. This abstraction simplifies the process by keeping the EntityPath definition confined to this repository.

Tested and the guard records are created as expected.