### PR TITLE
Spare guard reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,45 @@
 # GUARD
+
 Guarding the system against failures by permanently isolating faulty units.
-guard records contains the permanently isolated components details.
-GUARD repository provides the libraries and tools to create/list/delete guard records
+guard records contains the permanently isolated components details. GUARD
+repository provides the libraries and tools to create/list/delete guard records
+
 ## Building
+
 Need `meson` and `ninja`. Alternatively, source an OpenBMC ARM/x86 SDK.
+
 ```
 meson build && ninja -C build
 ```
+
 To use power system device for guard FRU's.
+
 ```
 meson build -Ddevtree=enabled && ninja -C build
 ```
+
 To build libguard with verbose level to get required trace.\
 Supported verbose level:\
-`0` - Emergency, `1` - Alert, `2` - Critical, `3` - Error, `4` - Warning,
-`5` - Notice, `6` - Info, `7` - Debug\
+`0` - Emergency, `1` - Alert, `2` - Critical, `3` - Error, `4` - Warning, `5` -
+Notice, `6` - Info, `7` - Debug\
 By default verbose level is Error.
+
 ```
 meson build -Dverbose=7 && ninja -C build
 ```
+
 ## To run unit tests
+
 Tests can be run in the CI docker container, or with an OpenBMC x86 sdk(see
 below for x86 steps).
+
 ```
 meson -Doe-sdk=enabled -Dtests=enabled build
 ninja -C build test
 ```
+
 ## Usage of GUARD tool
+
 ```
 
 guard --help
@@ -44,36 +57,46 @@ Options:
   -v,--version             Version of GUARD tool
 
 ```
-**Note:** Physical path can be fetched from device tree, using ATTR_PHYS_DEV_PATH
-attribute of the corresponding target.
-Physical path formats supported by guard tool:-
 
-* physical:sys-0/node-0/proc-0/mc-0/mi-0/mcc-0
-* /sys-0/node-0/proc-0/mc-0/mi-0/mcc-0
-* sys-0/node-0/proc-0/mc-0/mi-0/mcc-0
+**Note:** Physical path can be fetched from device tree, using
+ATTR_PHYS_DEV_PATH attribute of the corresponding target. Physical path formats
+supported by guard tool:-
+
+- physical:sys-0/node-0/proc-0/mc-0/mi-0/mcc-0
+- /sys-0/node-0/proc-0/mc-0/mi-0/mcc-0
+- sys-0/node-0/proc-0/mc-0/mi-0/mcc-0
 
 ### Examples
 
-* To create a guard record.
+- To create a guard record.
+
 ```
 guard -c sys-0/node-0/proc-0/mc-0/mi-0/mcc-0
 Success
 ```
-* To list the guard records present in a system.
+
+- To list the guard records present in a system.
+
 ```
 guard -l
-ID       | ERROR    |  Type  | Path 
+ID       | ERROR    |  Type  | Path
 00000001 | 00000000 | manual | physical:sys-0/node-0/proc-0/mc-0/mi-0/mcc-0
 ```
-* To erase all the guard records
+
+- To erase all the guard records
+
 ```
 guard -r
 ```
-* To invalidate a single guard record
+
+- To invalidate a single guard record
+
 ```
 guard -i 1
 ```
-* To invalidate all the guard records
+
+- To invalidate all the guard records
+
 ```
 guard -I
 ```

--- a/libguard/guard_entity.hpp
+++ b/libguard/guard_entity.hpp
@@ -29,7 +29,6 @@ const static reason guardreason = {
     {0xE9, "power"},          {0xEA, "hypervisor"}, {0xEB, "reconfig"},
     {0xEC, "sticky_deconfig"}};
 
-
 /**
  * @brief Return entity path for the corresponding physical path
  *

--- a/libguard/guard_entity.hpp
+++ b/libguard/guard_entity.hpp
@@ -24,9 +24,11 @@ const static std::map<int, std::string> PathType = {{0x00, "notApplicable"},
 
 using reason = std::map<int, std::string>;
 const static reason guardreason = {
-    {0x00, "noReason"},   {0xD2, "manual"},     {0xE2, "unrecoverable"},
-    {0xE3, "fatal"},      {0xE6, "predictive"}, {0xE9, "power"},
-    {0xEA, "hypervisor"}, {0xEB, "reconfig"},   {0xEC, "sticky_deconfig"}};
+    {0x00, "noReason"},       {0xC0, "spare"},      {0xD2, "manual"},
+    {0xE2, "unrecoverable"},  {0xE3, "fatal"},      {0xE6, "predictive"},
+    {0xE9, "power"},          {0xEA, "hypervisor"}, {0xEB, "reconfig"},
+    {0xEC, "sticky_deconfig"}};
+
 
 /**
  * @brief Return entity path for the corresponding physical path

--- a/libguard/guard_exception.hpp
+++ b/libguard/guard_exception.hpp
@@ -14,7 +14,7 @@ namespace exception
 class GuardException : public std::exception
 {
   public:
-    explicit GuardException(const std::string& message) : message(message){};
+    explicit GuardException(const std::string& message) : message(message) {};
 
     const char* what() const noexcept override
     {
@@ -28,61 +28,60 @@ class GuardException : public std::exception
 class InvalidGuardFile : public GuardException
 {
   public:
-    explicit InvalidGuardFile(const std::string& msg) :
-        GuardException(msg){};
+    explicit InvalidGuardFile(const std::string& msg) : GuardException(msg) {};
 };
 
 class GuardFileOpenFailed : public GuardException
 {
   public:
     explicit GuardFileOpenFailed(const std::string& msg) :
-        GuardException(msg){};
+        GuardException(msg) {};
 };
 
 class GuardFileReadFailed : public GuardException
 {
   public:
     explicit GuardFileReadFailed(const std::string& msg) :
-        GuardException(msg){};
+        GuardException(msg) {};
 };
 
 class GuardFileWriteFailed : public GuardException
 {
   public:
     explicit GuardFileWriteFailed(const std::string& msg) :
-        GuardException(msg){};
+        GuardException(msg) {};
 };
 
 class GuardFileSeekFailed : public GuardException
 {
   public:
     explicit GuardFileSeekFailed(const std::string& msg) :
-        GuardException(msg){};
+        GuardException(msg) {};
 };
 
 class InvalidEntry : public GuardException
 {
   public:
-    explicit InvalidEntry(const std::string& msg) : GuardException(msg){};
+    explicit InvalidEntry(const std::string& msg) : GuardException(msg) {};
 };
 
 class AlreadyGuarded : public GuardException
 {
   public:
-    explicit AlreadyGuarded(const std::string& msg) : GuardException(msg){};
+    explicit AlreadyGuarded(const std::string& msg) : GuardException(msg) {};
 };
 
 class InvalidEntityPath : public GuardException
 {
   public:
-    explicit InvalidEntityPath(const std::string& msg) : GuardException(msg){};
+    explicit InvalidEntityPath(const std::string& msg) : GuardException(msg) {};
 };
 
 class GuardFileOverFlowed : public GuardException
 {
   public:
     explicit GuardFileOverFlowed(const std::string& msg) :
-        GuardException(msg){};
+        GuardException(msg) {};
 };
 
 } // namespace exception

--- a/libguard/guard_interface.cpp
+++ b/libguard/guard_interface.cpp
@@ -280,13 +280,11 @@ GuardRecord create(const EntityPath& entityPath, uint32_t eId, uint8_t eType,
     return getHostEndiannessRecord(guard);
 }
 
-
-GuardRecord create(std::vector<uint8_t> rawPath, uint32_t eId,
-                   uint8_t eType,
+GuardRecord create(std::vector<uint8_t> rawPath, uint32_t eId, uint8_t eType,
                    bool overwriteRecord)
 {
-    return create(EntityPath(rawPath.data(), rawPath.size()), eId,
-    eType, overwriteRecord);
+    return create(EntityPath(rawPath.data(), rawPath.size()), eId, eType,
+                  overwriteRecord);
 }
 
 GuardRecords getAll(bool persistentTypeOnly)

--- a/libguard/guard_interface.hpp
+++ b/libguard/guard_interface.hpp
@@ -47,7 +47,8 @@ GuardRecord create(const EntityPath& entityPath, uint32_t eId = 0,
  *          based on the given "overwriteRecord" flag if that's meets
  *          a certain conditions that are defined in this function.
  *
- * @param[in] rawPathData entity path of the resource to be guarded as unit8 vector
+ * @param[in] rawPathData entity path of the resource to be guarded as unit8
+ * vector
  * @param[in] eId errorlog ID
  * @param[in] eType errorlog type
  * @param[in] overwriteRecord used to decide overwrite existing record

--- a/test/guard_intf_test.cpp
+++ b/test/guard_intf_test.cpp
@@ -143,8 +143,9 @@ TEST_F(TestGuardRecord, NegTestCaseFullGuardFile)
     openpower::guard::create(*entityPath);
     phyPath = "/sys-0/node-0/dimm-1";
     entityPath = openpower::guard::getEntityPath(phyPath);
-    EXPECT_THROW({ openpower::guard::create(*entityPath); },
-                 openpower::guard::exception::GuardFileOverFlowed);
+    EXPECT_THROW(
+        { openpower::guard::create(*entityPath); },
+        openpower::guard::exception::GuardFileOverFlowed);
 }
 
 TEST_F(TestGuardRecord, AlreadyGuardedTC)
@@ -156,8 +157,9 @@ TEST_F(TestGuardRecord, AlreadyGuardedTC)
     openpower::guard::create(*entityPath);
 
     // Trying to guard again with same entity
-    EXPECT_THROW({ openpower::guard::create(*entityPath); },
-                 openpower::guard::exception::AlreadyGuarded);
+    EXPECT_THROW(
+        { openpower::guard::create(*entityPath); },
+        openpower::guard::exception::AlreadyGuarded);
 }
 
 TEST_F(TestGuardRecord, GetCreatedGuardRecordTC)
@@ -206,8 +208,9 @@ TEST_F(TestGuardRecord, DeleteWithNotExistentEntity)
         openpower::guard::getEntityPath(physPath);
 
     // Trying to delete entity which is not present
-    EXPECT_THROW({ openpower::guard::clear(*entityPath); },
-                 openpower::guard::exception::InvalidEntityPath);
+    EXPECT_THROW(
+        { openpower::guard::clear(*entityPath); },
+        openpower::guard::exception::InvalidEntityPath);
 }
 
 TEST_F(TestGuardRecord, DeleteByRecordId)
@@ -241,8 +244,9 @@ TEST_F(TestGuardRecord, DeleteWithNotExistentRecordId)
         openpower::guard::create(*entityPath);
 
     // Trying to delete a record by using returned record id with increment
-    EXPECT_THROW({ openpower::guard::clear(retGuardRecord.recordId + 1); },
-                 openpower::guard::exception::InvalidEntityPath);
+    EXPECT_THROW(
+        { openpower::guard::clear(retGuardRecord.recordId + 1); },
+        openpower::guard::exception::InvalidEntityPath);
 }
 
 TEST_F(TestGuardRecord, GetGuardFilePathTC)
@@ -261,8 +265,9 @@ TEST_F(TestGuardRecord, GetGuardFilePathWhenLibguradDidNotInitTC)
     openpower::guard::utest::setGuardFile("");
 
     // Checking without libguard_init() call.
-    EXPECT_THROW({ openpower::guard::getGuardFilePath(); },
-                 openpower::guard::exception::GuardFileOpenFailed);
+    EXPECT_THROW(
+        { openpower::guard::getGuardFilePath(); },
+        openpower::guard::exception::GuardFileOpenFailed);
 
     // Set the guard file since UT reached the end
     openpower::guard::utest::setGuardFile(guardFile);


### PR DESCRIPTION
Spare guard is displayed as "unknown type" as "spare" is not listed in the known list of reasons. Fixed this by adding spare as one the reason. Tested and verified that it works as expected. Applied clang-format.